### PR TITLE
Update DM.ipynb

### DIFF
--- a/notes/DM.ipynb
+++ b/notes/DM.ipynb
@@ -557,7 +557,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Il caso interessante è quello in cui il tipo concreto è il sottotipo; in tal caso, una volta che il compilatore ha determinato che la segnatura da chiamare è `f(double)`, l'inocazione riguarderà però il codice presente nell'implementazione del tipo apparente:"
+    "Il caso interessante è quello in cui il tipo concreto è il sottotipo; in tal caso, una volta che il compilatore ha determinato che la segnatura da chiamare è `f(double)`, l'invocazione riguarderà però il codice presente nell'implementazione del tipo concreto:"
    ]
   },
   {


### PR DESCRIPTION
typo nel caso di tipo concreto è il sottotipo...non viene invocato il tipo apparente ma il tipo concreto